### PR TITLE
fixed the registration bug

### DIFF
--- a/TrackDr/Helpers/DatabaseHelper.cs
+++ b/TrackDr/Helpers/DatabaseHelper.cs
@@ -62,7 +62,7 @@ namespace TrackDr.Helpers
         }
         public AspNetUsers GetCurrentUser(string userName)
         {
-             return _context.AspNetUsers.Where(u => u.Email == userName).First(); // TODO add validation to makes sure that the user is logged in - if they are not logged in, re-rout to the register page before they are allowed to login! 
+                return _context.AspNetUsers.Where(u => u.Email == userName).First();
         }
         public Parent GetCurrentParent(AspNetUsers currentUser)
         {

--- a/TrackDr/Helpers/GAPIHelper.cs
+++ b/TrackDr/Helpers/GAPIHelper.cs
@@ -57,6 +57,7 @@ namespace TrackDr.Helpers
         }
         public void DetermineDistance(string startAddress, string endAddress)
         {
+
         }
     }
 }

--- a/TrackDr/Helpers/IGAPIHelper.cs
+++ b/TrackDr/Helpers/IGAPIHelper.cs
@@ -8,5 +8,8 @@ namespace TrackDr.Helpers
     public interface IGAPIHelper
     {
         string GetAPIKey();
+        string GooglefyUserAddress(string userName);
+        string GooglefyString(string toBeGooglefied);
+        void DetermineDistance(string startAddress, string endAddress);
     }
 }

--- a/TrackDr/Models/SavedInsurance.cs
+++ b/TrackDr/Models/SavedInsurance.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace TrackDr.Models
 {
-    public partial class Insurance
+    public class SavedInsurance
     {
         public string InsuranceBaseName { get; set; }
         public string InsuranceSpecialtyName { get; set; }

--- a/TrackDr/Models/TrackDrDbContext.cs
+++ b/TrackDr/Models/TrackDrDbContext.cs
@@ -25,9 +25,9 @@ namespace TrackDr.Models
         public virtual DbSet<Child> Child { get; set; }
         public virtual DbSet<ChildDoctor> ChildDoctor { get; set; }
         public virtual DbSet<Doctor> Doctor { get; set; }
-        public virtual DbSet<Insurance> Insurance { get; set; }
         public virtual DbSet<Parent> Parent { get; set; }
         public virtual DbSet<ParentDoctor> ParentDoctor { get; set; }
+        public virtual DbSet<SavedInsurance> SavedInsurance { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -178,23 +178,6 @@ namespace TrackDr.Models
                 entity.Property(e => e.DoctorId).ValueGeneratedNever();
             });
 
-            modelBuilder.Entity<Insurance>(entity =>
-            {
-                entity.HasKey(e => e.InsuranceUid)
-                    .HasName("PK__Insuranc__E770AC3DDC00211E");
-
-                entity.Property(e => e.InsuranceUid)
-                    .HasColumnName("InsuranceUID")
-                    .HasMaxLength(128)
-                    .ValueGeneratedNever();
-
-                entity.Property(e => e.InsuranceBaseName)
-                    .IsRequired()
-                    .HasMaxLength(64);
-
-                entity.Property(e => e.InsuranceSpecialtyName).HasMaxLength(128);
-            });
-
             modelBuilder.Entity<Parent>(entity =>
             {
                 entity.Property(e => e.ParentId).ValueGeneratedNever();
@@ -205,9 +188,7 @@ namespace TrackDr.Models
 
                 entity.Property(e => e.Email).HasMaxLength(128);
 
-                entity.Property(e => e.HouseNumber)
-                    .IsRequired()
-                    .HasMaxLength(16);
+                entity.Property(e => e.HouseNumber).HasMaxLength(16);
 
                 entity.Property(e => e.InsuranceBaseName).HasMaxLength(64);
 
@@ -217,9 +198,7 @@ namespace TrackDr.Models
                     .IsRequired()
                     .HasMaxLength(32);
 
-                entity.Property(e => e.Street)
-                    .IsRequired()
-                    .HasMaxLength(64);
+                entity.Property(e => e.Street).HasMaxLength(64);
 
                 entity.Property(e => e.Street2).HasMaxLength(64);
 
@@ -243,6 +222,23 @@ namespace TrackDr.Models
                     .WithMany(p => p.ParentDoctor)
                     .HasForeignKey(d => d.ParentId)
                     .HasConstraintName("FK__ParentDoc__Paren__5535A963");
+            });
+
+            modelBuilder.Entity<SavedInsurance>(entity =>
+            {
+                entity.HasKey(e => e.InsuranceUid)
+                    .HasName("PK__Insuranc__E770AC3DBA24CC1B");
+
+                entity.Property(e => e.InsuranceUid)
+                    .HasColumnName("InsuranceUID")
+                    .HasMaxLength(128)
+                    .ValueGeneratedNever();
+
+                entity.Property(e => e.InsuranceBaseName)
+                    .IsRequired()
+                    .HasMaxLength(64);
+
+                entity.Property(e => e.InsuranceSpecialtyName).HasMaxLength(128);
             });
         }
     }

--- a/TrackDr/Models/TravelInfo.cs
+++ b/TrackDr/Models/TravelInfo.cs
@@ -5,8 +5,7 @@ using System.Threading.Tasks;
 
 namespace TrackDr.Models
 {
-
-    public class Rootobject
+    public class TravelInfo
     {
         public string[] destination_addresses { get; set; }
         public string[] origin_addresses { get; set; }
@@ -37,5 +36,4 @@ namespace TrackDr.Models
         public string text { get; set; }
         public int value { get; set; }
     }
-
 }

--- a/TrackDr/Views/Home/Locations.cshtml
+++ b/TrackDr/Views/Home/Locations.cshtml
@@ -1,0 +1,15 @@
+﻿
+@{
+    ViewData["Title"] = "Locations";
+}
+
+@model SingleDoctor
+
+<h1>Locations</h1>
+
+<table></table>
+@{ foreach (Practice location in Model.data.practices)
+    {
+        @location.visit_address;
+    }
+}


### PR DESCRIPTION
when registering, error would appear linked to the insurance class. determined the issue was because the insurance class of the doctor class was named the same as the database table. updated the database, parent and doctor classes, and deleted the insuarnce class after rescaffolding.